### PR TITLE
Delete unnecessary method for Jansson

### DIFF
--- a/octopass.c
+++ b/octopass.c
@@ -424,12 +424,10 @@ int octopass_github_team_id(char *team_name, char *data)
     const char *name = json_string_value(json_object_get(team, "name"));
     if (name != NULL && strcmp(team_name, name) == 0) {
       const json_int_t id = json_integer_value(json_object_get(team, "id"));
-      json_decref(teams);
       return id;
     }
   }
 
-  json_decref(teams);
   return 0;
 }
 
@@ -534,11 +532,8 @@ int octopass_autentication_with_token(struct config *con, char *user, char *toke
     const char *login = json_string_value(json_object_get(root, "login"));
 
     if (strcmp(login, user) == 0) {
-      json_decref(root);
       return 0;
     }
-
-    json_decref(root);
   }
 
   if (con->syslog) {
@@ -565,7 +560,6 @@ const char *octopass_only_keys(char *data)
 
   const char *res = strdup(keys);
   free(keys);
-  json_decref(root);
 
   return res;
 }
@@ -604,7 +598,6 @@ const char *octopass_github_team_members_keys(struct config *con)
   free(res.data);
 
   if (!json_is_array(root)) {
-    json_decref(root);
     return NULL;
   }
 
@@ -629,7 +622,6 @@ const char *octopass_github_team_members_keys(struct config *con)
 
   const char *result = strdup(members_keys);
   free(members_keys);
-  json_decref(root);
 
   return (strlen(result) > 0) ? result : NULL;
 }

--- a/octopass.c
+++ b/octopass.c
@@ -418,6 +418,9 @@ int octopass_github_team_id(char *team_name, char *data)
   int i;
 
   json_array_foreach(teams, i, team) {
+    if (!json_is_object(team)) {
+      continue;
+    }
     const char *name = json_string_value(json_object_get(team, "name"));
     if (name != NULL && strcmp(team_name, name) == 0) {
       const json_int_t id = json_integer_value(json_object_get(team, "id"));

--- a/octopass.h
+++ b/octopass.h
@@ -34,7 +34,7 @@
 #include <sys/stat.h>
 #include <regex.h>
 
-#define OCTOPASS_VERSION "0.3.4"
+#define OCTOPASS_VERSION "0.3.5"
 #define OCTOPASS_VERSION_WITH_NAME "octopass/" OCTOPASS_VERSION
 #ifndef OCTOPASS_CONFIG_FILE
 #define OCTOPASS_CONFIG_FILE "/etc/octopass.conf"


### PR DESCRIPTION
Fix for #12. Delete `json_decref` method because it is unnecessary. :sob: