### PR TITLE
Support debian jessie/stretch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,7 @@ deb: source_for_deb ## Packaging for DEB
 		dh_make --single --createorig -y && \
 		rm -rf debian/*.ex debian/*.EX debian/README.Debian && \
 		cp -v /octopass/debian/* debian/ && \
+		sed -i -e 's/xenial/$(DIST)/g' debian/changelog && \
 		debuild -uc -us
 	cd tmp.$(DIST) && \
 		find . -name "*.deb" | sed -e 's/\(\(.*octopass_.*\).deb\)/mv \1 \2.$(DIST).deb/g' | sh && \

--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,8 @@ packagecloud_release: ## Upload archives to PackageCloud on Mac
 	pkgcloud-push linyows/octopass/ubuntu/xenial builds/octopass_$(VERSION)-1_amd64.xenial.deb
 	pkgcloud-push linyows/octopass/ubuntu/trusty builds/octopass_$(VERSION)-1_amd64.trusty.deb
 	pkgcloud-push linyows/octopass/ubuntu/precise builds/octopass_$(VERSION)-1_amd64.precise.deb
+	pkgcloud-push linyows/octopass/debian/stretch builds/octopass_$(VERSION)-1_amd64.stretch.deb
+	pkgcloud-push linyows/octopass/debian/jessie builds/octopass_$(VERSION)-1_amd64.jessie.deb
 
 pkg: ## Create some distribution packages
 	rm -rf builds && mkdir builds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ deb9:
     - .:/octopass
   environment:
     DIST: stretch
+    DEB_BUILD_OPTIONS: noautodbgsym
   command: make deb
 deb8:
   dockerfile: dockerfiles/Dockerfile.debian-8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,20 @@ deb12:
   environment:
     DIST: precise
   command: make deb12
+
+deb9:
+  dockerfile: dockerfiles/Dockerfile.debian-9
+  build: .
+  volumes:
+    - .:/octopass
+  environment:
+    DIST: stretch
+  command: make deb
+deb8:
+  dockerfile: dockerfiles/Dockerfile.debian-8
+  build: .
+  volumes:
+    - .:/octopass
+  environment:
+    DIST: jessie
+  command: make deb

--- a/dockerfiles/Dockerfile.debian-8
+++ b/dockerfiles/Dockerfile.debian-8
@@ -1,0 +1,11 @@
+FROM debian:jessie
+MAINTAINER linyows <linyows@gmail.com>
+
+RUN apt-get -qq update && \
+    apt-get install -qq glibc-source gcc make libcurl4-gnutls-dev libjansson-dev \
+                        bzip2 unzip debhelper dh-make devscripts cdbs clang
+
+ENV USER root
+
+RUN mkdir /octopass
+WORKDIR /octopass

--- a/dockerfiles/Dockerfile.debian-9
+++ b/dockerfiles/Dockerfile.debian-9
@@ -1,0 +1,11 @@
+FROM debian:stretch
+MAINTAINER linyows <linyows@gmail.com>
+
+RUN apt-get -qq update && \
+    apt-get install -qq glibc-source gcc make libcurl4-gnutls-dev libjansson-dev \
+                        bzip2 unzip debhelper dh-make devscripts cdbs clang
+
+ENV USER root
+
+RUN mkdir /octopass
+WORKDIR /octopass


### PR DESCRIPTION
Octopass is nice tool.
I want to use in debian.
This change is add for debian jessie/stretch package.

----
Sorry, integration test is failed,
see also https://github.com/linyows/octopass/pull/22#issuecomment-377462474