### PR TITLE
Fix packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,14 +126,6 @@ rpm: source_for_rpm ## Packaging for RPM
 	rpmbuild -ba rpm/octopass.spec
 	cp /root/rpmbuild/RPMS/*/*.rpm /octopass/builds
 
-rpm5: jansson source_for_rpm ## Packaging for RPM-5
-	@echo "$(INFO_COLOR)==> $(RESET)$(BOLD)Packaging for RPM$(RESET)"
-	mkdir -p /usr/src/redhat/SOURCES
-	cp builds/octopass-$(VERSION).tar.gz /usr/src/redhat/SOURCES
-	rpmbuild -ba rpm/octopass.spec
-	cp /usr/src/redhat/RPMS/*/*.rpm /octopass/builds
-	mv /octopass/builds/{octopass-$(VERSION)-1.el5.x86_64.rpm,octopass-$(VERSION)-1.x86_64.el5.rpm}
-
 jansson: build_dir ## Build and Install Janson
 	@echo "$(INFO_COLOR)==> $(RESET)$(BOLD)Building and Installing Jansson$(RESET)"
 	mkdir -p /usr/src/redhat/SOURCES

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-rpm7:
+centos7:
   dockerfile: dockerfiles/Dockerfile.centos-7
   build: .
   volumes:
@@ -6,7 +6,7 @@ rpm7:
   environment:
     DIST: el7
   command: make rpm
-rpm6:
+centos6:
   dockerfile: dockerfiles/Dockerfile.centos-6
   build: .
   volumes:
@@ -15,7 +15,7 @@ rpm6:
     DIST: el6
   command: make rpm
 
-deb16:
+ubuntu16:
   dockerfile: dockerfiles/Dockerfile.ubuntu-16
   build: .
   volumes:
@@ -23,7 +23,7 @@ deb16:
   environment:
     DIST: xenial
   command: make deb
-deb14:
+ubuntu14:
   dockerfile: dockerfiles/Dockerfile.ubuntu-14
   build: .
   volumes:
@@ -31,7 +31,7 @@ deb14:
   environment:
     DIST: trusty
   command: make deb
-deb12:
+ubuntu12:
   dockerfile: dockerfiles/Dockerfile.ubuntu-12
   build: .
   volumes:
@@ -40,7 +40,7 @@ deb12:
     DIST: precise
   command: make deb12
 
-deb9:
+debian9:
   dockerfile: dockerfiles/Dockerfile.debian-9
   build: .
   volumes:
@@ -49,7 +49,7 @@ deb9:
     DIST: stretch
     DEB_BUILD_OPTIONS: noautodbgsym
   command: make deb
-deb8:
+debian8:
   dockerfile: dockerfiles/Dockerfile.debian-8
   build: .
   volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,6 @@ rpm6:
   environment:
     DIST: el6
   command: make rpm
-rpm5:
-  dockerfile: dockerfiles/Dockerfile.centos-5
-  build: .
-  volumes:
-    - .:/octopass
-  environment:
-    DIST: el5
-  command: make rpm5
 
 deb16:
   dockerfile: dockerfiles/Dockerfile.ubuntu-16

--- a/dockerfiles/Dockerfile.debian-9
+++ b/dockerfiles/Dockerfile.debian-9
@@ -3,7 +3,7 @@ MAINTAINER linyows <linyows@gmail.com>
 
 RUN apt-get -qq update && \
     apt-get install -qq glibc-source gcc make libcurl4-gnutls-dev libjansson-dev \
-                        bzip2 unzip debhelper dh-make devscripts cdbs clang
+                        bzip2 unzip debhelper dh-make devscripts cdbs clang apt-utils
 
 ENV USER root
 


### PR DESCRIPTION
Remove CentOS 5 from the support package. Also add the missing package with debian stretch. This will allow you to build properly.