### PR TITLE
Support slug for github team API

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+octopass (0.5.0-1) bionic; urgency=medium
+
+  * Support slug for GitHub team API
+
+ -- linyows <linyows@gmail.com>  Thu, 02 Oct 2018 14:40:00 +0900
 octopass (0.4.1-1) xenial; urgency=medium
 
   * Page size changes to 100 from 30 on Github organization API

--- a/octopass.c
+++ b/octopass.c
@@ -465,6 +465,11 @@ int octopass_github_team_id(char *team_name, char *data)
       const json_int_t id = json_integer_value(json_object_get(team, "id"));
       return id;
     }
+    const char *slug = json_string_value(json_object_get(team, "slug"));
+    if (name != NULL && strcmp(team_name, slug) == 0) {
+      const json_int_t id = json_integer_value(json_object_get(team, "id"));
+      return id;
+    }
   }
 
   return -1;
@@ -520,6 +525,7 @@ int octopass_team_id(struct config *con)
 
   int id = octopass_github_team_id(con->team, res.data);
   free(res.data);
+
   return id;
 }
 

--- a/octopass.c
+++ b/octopass.c
@@ -551,6 +551,9 @@ int octopass_team_members(struct config *con, struct response *res)
 {
   int team_id = octopass_team_id(con);
   if (team_id == -1) {
+    if (con->syslog) {
+      syslog(LOG_INFO, "team not found: %s", con->team);
+    }
     return -1;
   }
 

--- a/octopass.h
+++ b/octopass.h
@@ -34,7 +34,7 @@
 #include <sys/stat.h>
 #include <regex.h>
 
-#define OCTOPASS_VERSION "0.4.1"
+#define OCTOPASS_VERSION "0.5.0"
 #define OCTOPASS_VERSION_WITH_NAME "octopass/" OCTOPASS_VERSION
 #ifndef OCTOPASS_CONFIG_FILE
 #define OCTOPASS_CONFIG_FILE "/etc/octopass.conf"

--- a/rpm/octopass.spec
+++ b/rpm/octopass.spec
@@ -1,6 +1,6 @@
 Summary:          Management linux user and authentication with team or collaborator on Github.
 Name:             octopass
-Version:          0.4.1
+Version:          0.5.0
 Release:          1
 License:          GPLv3
 URL:              https://github.com/linyows/octopass
@@ -56,6 +56,8 @@ install -m 644 octopass.conf.example %{buildroot}%{_sysconfdir}/octopass.conf.ex
 /etc/octopass.conf.example
 
 %changelog
+* Thu Oct 02 2018 linyows <linyows@gmail.com> - 0.5.0-1
+- Support slug for GitHub team API
 * Mon Apr 02 2018 linyows <linyows@gmail.com> - 0.4.1-1
 - Page size changes to 100 from 30 on Github organization API
 * Mon Sep 25 2017 linyows <linyows@gmail.com> - 0.4.0-1


### PR DESCRIPTION
This enhancement for #28. With this change, you can specify it not only with github team name but also with slug.

```sh
curl -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/orgs/your-org/teams
[
  {
    "name": "Super Engineer",# <--- current
    "id": 00000,
    "node_id": "MMMMMMMMMM=",
    "slug": "engineer",# <--- new add
    "description": "",
    "privacy": "closed",
    "url": "https://api.github.com/teams/00000",
    "members_url": "https://api.github.com/teams/00000/members{/member}",
    "repositories_url": "https://api.github.com/teams/00000/repos",
    "permission": "pull"
  }
]
```

like this:

```sh
$ cat /etc/octopass.conf
...
Token           = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
Organization    = "your-org"
Team            = "engineer"
...
```