### PR TITLE
Fix SEGV for systemd-networkd starting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ octopass
 octopass.conf
 exports
 builds
+/*console.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(2) do |config|
 
   cmd_ubuntu = <<-CMD
     apt-get -yy update
-    apt-get install -yy glibc-source gcc make libcurl4-gnutls-dev libjansson-dev vim
+    apt-get install -yy glibc-source gcc make libcurl4-gnutls-dev libjansson-dev vim valgrind
     timedatectl set-timezone Asia/Tokyo
   CMD
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure(2) do |config|
 
   cmd_ubuntu = <<-CMD
     apt-get -yy update
-    apt-get install -yy glibc-source gcc make libcurl4-gnutls-dev libjansson-dev vim valgrind
+    apt-get install -yy glibc-source gcc make libcurl4-gnutls-dev libjansson-dev vim valgrind systemd-coredump
     timedatectl set-timezone Asia/Tokyo
   CMD
 
@@ -25,8 +25,7 @@ Vagrant.configure(2) do |config|
     cp /octopass/misc/octopass.conf /etc/octopass.conf
     cp /octopass/misc/nsswitch.conf /etc/nsswitch.conf
     sed -i 's/GITHUB_TOKEN/#{ENV['GITHUB_TOKEN']}/' /etc/octopass.conf
-    sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub
-    update-grub
+    ulimit -c unlimited
   CMD
 
   config.vm.define :ubuntu do |c|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,8 @@ Vagrant.configure(2) do |config|
     cp /octopass/misc/octopass.conf /etc/octopass.conf
     cp /octopass/misc/nsswitch.conf /etc/nsswitch.conf
     sed -i 's/GITHUB_TOKEN/#{ENV['GITHUB_TOKEN']}/' /etc/octopass.conf
+    sed -ie 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub
+    update-grub
   CMD
 
   config.vm.define :ubuntu do |c|

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+octopass (0.5.1-1) bionic; urgency=medium
+
+  * Fix for systemd-networkd SEGV
+
+ -- linyows <linyows@gmail.com>  Wed, 10 Oct 2018 00:20:00 +0900
 octopass (0.5.0-1) bionic; urgency=medium
 
   * Support slug for GitHub team API

--- a/misc/nsswitch.conf
+++ b/misc/nsswitch.conf
@@ -1,0 +1,20 @@
+# /etc/nsswitch.conf
+#
+# Example configuration of GNU Name Service Switch functionality.
+# If you have the `glibc-doc-reference' and `info' packages installed, try:
+# `info libc "Name Service Switch"' for information about this file.
+
+passwd:         compat systemd octopass
+group:          compat systemd octopass
+shadow:         compat octopass
+gshadow:        files
+
+hosts:          files dns
+networks:       files
+
+protocols:      db files
+services:       db files
+ethers:         db files
+rpc:            db files
+
+netgroup:       nis

--- a/misc/octopass.conf
+++ b/misc/octopass.conf
@@ -1,0 +1,25 @@
+# O C T O P A S S
+
+# Required
+Token           = "GITHUB_TOKEN"
+
+## Use team
+Organization    = "fukuokago"
+Team            = "admin"
+
+## Use collaborators
+#Owner           = "yourname"
+#Repository      = "yourrepository"
+
+# Default
+#Endpoint        = "https://api.github.com/"
+#Group           = "yourgroup"
+#Home            = "/home/foo/%s"
+#Shell           = "/bin/zsh"
+#UidStarts       = 2000
+#Gid             = 2000
+#Cache           = 300
+Syslog          = true
+
+# Advanced
+#SharedUsers     = [ "admin", "deploy" ]

--- a/octopass.c
+++ b/octopass.c
@@ -389,7 +389,11 @@ void octopass_github_request_without_cache(struct config *con, char *url, struct
   result = curl_easy_perform(hnd);
 
   if (result != CURLE_OK) {
-    fprintf(stderr, "cURL failed: %s\n", curl_easy_strerror(result));
+    if (con->syslog) {
+      syslog(LOG_ERR, "cURL failed: %s", curl_easy_strerror(result));
+    } else {
+      fprintf(stderr, "cURL failed: %s\n", curl_easy_strerror(result));
+    }
   } else {
     long *code;
     curl_easy_getinfo(hnd, CURLINFO_RESPONSE_CODE, &code);

--- a/octopass.c
+++ b/octopass.c
@@ -265,6 +265,7 @@ void octopass_config_loading(struct config *con, char *filename)
       char *pattern           = "\"([A-z0-9_-]+)\"";
       con->shared_users       = calloc(MAXBUF, sizeof(char *));
       con->shared_users_count = octopass_match(value, pattern, con->shared_users);
+      free(value);
     }
   }
 

--- a/octopass.h
+++ b/octopass.h
@@ -73,7 +73,7 @@ struct config {
   char organization[MAXBUF];
   char team[MAXBUF];
   char owner[MAXBUF];
-  char repository[MAXBUF];
+  char repository[2048];
   char permission[MAXBUF];
   char group_name[MAXBUF];
   char home[MAXBUF];

--- a/octopass.h
+++ b/octopass.h
@@ -34,7 +34,7 @@
 #include <sys/stat.h>
 #include <regex.h>
 
-#define OCTOPASS_VERSION "0.5.0"
+#define OCTOPASS_VERSION "0.5.1"
 #define OCTOPASS_VERSION_WITH_NAME "octopass/" OCTOPASS_VERSION
 #ifndef OCTOPASS_CONFIG_FILE
 #define OCTOPASS_CONFIG_FILE "/etc/octopass.conf"

--- a/rpm/octopass.spec
+++ b/rpm/octopass.spec
@@ -1,6 +1,6 @@
 Summary:          Management linux user and authentication with team or collaborator on Github.
 Name:             octopass
-Version:          0.5.0
+Version:          0.5.1
 Release:          1
 License:          GPLv3
 URL:              https://github.com/linyows/octopass
@@ -56,6 +56,8 @@ install -m 644 octopass.conf.example %{buildroot}%{_sysconfdir}/octopass.conf.ex
 /etc/octopass.conf.example
 
 %changelog
+* Wed Oct 10 2018 linyows <linyows@gmail.com> - 0.5.1-1
+- Fix for systemd-networkd SEGV
 * Thu Oct 02 2018 linyows <linyows@gmail.com> - 0.5.0-1
 - Support slug for GitHub team API
 * Mon Apr 02 2018 linyows <linyows@gmail.com> - 0.4.1-1


### PR DESCRIPTION
This change for #30. This is a temporary fix. After this, change the char of the struct from an array to a pointer.

```sh
root@ubuntu-bionic:/home/vagrant# coredumpctl list
TIME                            PID   UID   GID SIG COREFILE  EXE
Tue 2018-10-09 23:27:41 JST     600     0     0  11 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:41 JST     620     0     0  11 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:41 JST     649     0     0  11 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:41 JST     665     0     0  11 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:42 JST     679     0     0  11 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:43 JST     912     0     0  11 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:43 JST    1020     0     0   6 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:44 JST    1039     0     0   6 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:44 JST    1051     0     0  11 present   /lib/systemd/systemd
Tue 2018-10-09 23:27:44 JST    1060     0     0  11 present   /lib/systemd/systemd
root@ubuntu-bionic:/home/vagrant# coredumpctl gdb 679
           PID: 679 ((networkd))
           UID: 0 (root)
           GID: 0 (root)
        Signal: 11 (SEGV)
     Timestamp: Tue 2018-10-09 23:27:42 JST (21min ago)
  Command Line: (networkd)
    Executable: /lib/systemd/systemd
 Control Group: /system.slice/systemd-networkd.service
          Unit: systemd-networkd.service
         Slice: system.slice
       Boot ID: 36809788956149bcbbb05c7906bf523e
    Machine ID: 391bc82dbf554afe8fbcc70dea756a73
      Hostname: ubuntu-bionic
       Storage: /var/lib/systemd/coredump/core.(networkd).0.36809788956149bcbbb05c7906bf523e.679.1539095262000000.lz4
       Message: Process 679 ((networkd)) of user 0 dumped core.

                Stack trace of thread 679:
                #0  0x00007fcaa5e86c01 __GI___libc_free (libc.so.6)
                #1  0x00007fca9b379e50 _nss_octopass_setgrent_locked (libnss_octopass.so.2)
                #2  0x00007fca9b379fb1 _nss_octopass_setgrent (libnss_octopass.so.2)
                #3  0x00007fcaa5ecf73a compat_call (libc.so.6)
                #4  0x00007fcaa5ecfb6e internal_getgrouplist (libc.so.6)
                #5  0x00007fcaa5ecfdbd initgroups (libc.so.6)
                #6  0x0000555d7db9db82 n/a (systemd)
                #7  0x0000555d7dbe8aa5 n/a (systemd)
                #8  0x0000555d7dc02739 n/a (systemd)
                #9  0x0000555d7dc04578 n/a (systemd)
                #10 0x0000555d7dc049e5 n/a (systemd)
                #11 0x0000555d7dbe54a2 n/a (systemd)
                #12 0x0000555d7dbb85ea n/a (systemd)
                #13 0x00007fcaa5a24d2a n/a (libsystemd-shared-237.so)
                #14 0x00007fcaa5a2507a sd_event_dispatch (libsystemd-shared-237.so)
                #15 0x00007fcaa5a25209 sd_event_run (libsystemd-shared-237.so)
                #16 0x0000555d7dc482cd n/a (systemd)
                #17 0x0000555d7dba426c n/a (systemd)
                #18 0x00007fcaa5e10b97 __libc_start_main (libc.so.6)
                #19 0x0000555d7dba515a n/a (systemd)
```