### PR TITLE
Fix permission issue when cache expired

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ build_dir: ## Create directory for build
 	test -d $(BUILD) || mkdir -p $(BUILD)
 
 cache_dir: ## Create directory for cache
-	test -d $(CACHE) || mkdir -p $(CACHE)
+	test -d $(CACHE) || mkdir -p $(CACHE) && chmod 777 $(CACHE)
 
 deps: ## Install dependencies
 	@echo "$(INFO_COLOR)==> $(RESET)$(BOLD)Installing Dependencies$(RESET)"

--- a/debian/postinst
+++ b/debian/postinst
@@ -21,6 +21,7 @@ set -e
 case "$1" in
     configure)
         mkdir -p /var/cache/octopass
+        chmod 777 /var/cache/octopass
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/octopass.h
+++ b/octopass.h
@@ -33,6 +33,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <regex.h>
+#include <unistd.h>
 
 #define OCTOPASS_VERSION "0.6.0"
 #define OCTOPASS_VERSION_WITH_NAME "octopass/" OCTOPASS_VERSION

--- a/octopass_test.c
+++ b/octopass_test.c
@@ -178,9 +178,14 @@ Test(octopass, config_loading__when_use_repository)
 
 Test(octopass, export_file)
 {
+  struct config con;
+  char *cf = "test/octopass.conf";
+  octopass_config_loading(&con, cf);
+
+  char *dir = "/tmp";
   char *f = "/tmp/octopass-export_file_test_1.txt";
   char *d = "LINE1\nLINE2\nLINE3\n";
-  octopass_export_file(f, d);
+  octopass_export_file(&con, dir, f, d);
 
   FILE *fp = fopen(f, "r");
 
@@ -211,16 +216,21 @@ Test(octopass, export_file)
 
 Test(octopass, import_file)
 {
+  struct config con;
+  char *cf = "test/octopass.conf";
+  octopass_config_loading(&con, cf);
+
+  char *dir = "/tmp";
   char *f1 = "/tmp/octopass-import_file_test_1.txt";
   char *d1 = "LINE1\nLINE2\nLINE3\n";
-  octopass_export_file(f1, d1);
-  const char *data1 = octopass_import_file(f1);
+  octopass_export_file(&con, dir, f1, d1);
+  const char *data1 = octopass_import_file(&con, f1);
   cr_assert_str_eq(data1, d1);
 
   char *f2 = "/tmp/octopass-import_file_test_2.txt";
   char *d2 = "LINEa\nLINEb\nLINEc\n";
-  octopass_export_file(f2, d2);
-  const char *data2 = octopass_import_file(f2);
+  octopass_export_file(&con, dir, f2, d2);
+  const char *data2 = octopass_import_file(&con, f2);
   cr_assert_str_eq(data2, d2);
 }
 
@@ -341,7 +351,7 @@ Test(octopass, rebuild_data_with_authorized, .init = setup)
 
   char *stub = "test/collaborators.json";
   res.httpstatus = (long *)200;
-  res.data = (char *)octopass_import_file(stub);
+  res.data = (char *)octopass_import_file(&con, stub);
   res.size = strlen(res.data);
   octopass_rebuild_data_with_authorized(&con, &res);
 
@@ -373,7 +383,7 @@ Test(octopass, rebuild_data_with_authorized__when_permission_is_read, .init = se
 
   char *stub = "test/collaborators.json";
   res.httpstatus = (long *)200;
-  res.data = (char *)octopass_import_file(stub);
+  res.data = (char *)octopass_import_file(&con, stub);
   res.size = strlen(res.data);
   octopass_rebuild_data_with_authorized(&con, &res);
 

--- a/rpm/octopass.spec
+++ b/rpm/octopass.spec
@@ -68,7 +68,7 @@ fi
 /usr/lib64/libnss_octopass.so.2
 /usr/lib64/libnss_octopass.so.2.0
 /usr/bin/octopass
-/var/cache/octopass
+%attr(0777,root,root) /var/cache/octopass
 /etc/octopass.conf.example
 %{_datadir}/selinux/packages/%{name}/%{name}.pp
 


### PR DESCRIPTION
If the cache file expires while keep the login session, an error "File open failure" will occur when trying to get user and group IDs. (e.g. id)
So, I modified cache file permission and directory structure it with refer to libstns.