### PR TITLE
update README to support http-proxy environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Installation
 Ubuntu:
 
 ```sh
-$ curl -s https://packagecloud.io/install/repositories/linyows/octopass/script.deb.sh | sudo bash
+$ curl -s https://packagecloud.io/install/repositories/linyows/octopass/script.deb.sh | sudo -E bash
 $ sudo apt-get install octopass
 ```
 


### PR DESCRIPTION
Running on http-proxy environment, I could not install octopass because `sudo bash` could not read environment vars. 

```sh
$ export | grep -i http
declare -x http_proxy="http://192.168.210.1:8080/"
declare -x https_proxy="http://192.168.210.1:8080/"

$ curl -s https://packagecloud.io/install/repositories/linyows/octopass/script.deb.sh | sudo bash
Installing /etc/apt/sources.list.d/linyows_octopass.list...curl: (7) Failed to connect to packagecloud.io port 443: Connection refused

Unable to run:
    curl https://packagecloud.io/install/repositories/linyows/octopass/config_file.list?os=Ubuntu&dist=bionic&source=script

Double check your curl installation and try again.
```

see also: https://linux.die.net/man/8/sudo