### PR TITLE
Fix null pointer for libc_free

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -193,15 +193,17 @@ github_release: pkg ## Upload archives to Github Release on Mac
 packagecloud_release: ## Upload archives to PackageCloud on Mac
 	@echo "$(INFO_COLOR)==> $(RESET)$(BOLD)Releasing for PackageCloud$(RESET)"
 	go get github.com/mlafeldt/pkgcloud/...
+	pkgcloud-push linyows/octopass/el/8 builds/octopass-$(VERSION)-1.x86_64.el8.rpm
 	pkgcloud-push linyows/octopass/el/7 builds/octopass-$(VERSION)-1.x86_64.el7.rpm
-	pkgcloud-push linyows/octopass/el/6 builds/octopass-$(VERSION)-1.x86_64.el6.rpm
+	#pkgcloud-push linyows/octopass/el/6 builds/octopass-$(VERSION)-1.x86_64.el6.rpm
+	pkgcloud-push linyows/octopass/ubuntu/focal builds/octopass_$(VERSION)-1_amd64.focal.deb
 	pkgcloud-push linyows/octopass/ubuntu/bionic builds/octopass_$(VERSION)-1_amd64.bionic.deb
-	pkgcloud-push linyows/octopass/ubuntu/xenial builds/octopass_$(VERSION)-1_amd64.xenial.deb
-	pkgcloud-push linyows/octopass/ubuntu/trusty builds/octopass_$(VERSION)-1_amd64.trusty.deb
-	pkgcloud-push linyows/octopass/ubuntu/precise builds/octopass_$(VERSION)-1_amd64.precise.deb
-	pkgcloud-push linyows/octopass/debian/stretch builds/octopass_$(VERSION)-1_amd64.stretch.deb
-	pkgcloud-push linyows/octopass/debian/jessie builds/octopass_$(VERSION)-1_amd64.jessie.deb
+	#pkgcloud-push linyows/octopass/ubuntu/xenial builds/octopass_$(VERSION)-1_amd64.xenial.deb
+	#pkgcloud-push linyows/octopass/ubuntu/trusty builds/octopass_$(VERSION)-1_amd64.trusty.deb
+	#pkgcloud-push linyows/octopass/ubuntu/precise builds/octopass_$(VERSION)-1_amd64.precise.deb
 	pkgcloud-push linyows/octopass/debian/buster builds/octopass_$(VERSION)-1_amd64.buster.deb
+	pkgcloud-push linyows/octopass/debian/stretch builds/octopass_$(VERSION)-1_amd64.stretch.deb
+	#pkgcloud-push linyows/octopass/debian/jessie builds/octopass_$(VERSION)-1_amd64.jessie.deb
 
 pkg: ## Create some distribution packages
 	rm -rf builds && mkdir builds

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+octopass (0.7.1-1) focal; urgency=medium
+
+  * Bugfixes
+
+ -- linyows <linyows@gmail.com>  Thu, 27 Apr 2021 15:30:00 +0900
 octopass (0.7.0-1) bionic; urgency=medium
 
   * Resolve a problem of cache file permission

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,14 @@ centos7:
   environment:
     DIST: el7
   command: make rpm
-centos6:
-  dockerfile: dockerfiles/Dockerfile.centos-6
-  build: .
-  volumes:
-    - .:/octopass
-  environment:
-    DIST: el6
-  command: make rpm
+  #centos6:
+  #  dockerfile: dockerfiles/Dockerfile.centos-6
+  #  build: .
+  #  volumes:
+  #    - .:/octopass
+  #  environment:
+  #    DIST: el6
+  #  command: make rpm
 
 ubuntu20:
   dockerfile: dockerfiles/Dockerfile.ubuntu-20
@@ -39,30 +39,30 @@ ubuntu18:
   environment:
     DIST: bionic
   command: make deb
-ubuntu16:
-  dockerfile: dockerfiles/Dockerfile.ubuntu-16
-  build: .
-  volumes:
-    - .:/octopass
-  environment:
-    DIST: xenial
-  command: make deb
-ubuntu14:
-  dockerfile: dockerfiles/Dockerfile.ubuntu-14
-  build: .
-  volumes:
-    - .:/octopass
-  environment:
-    DIST: trusty
-  command: make deb
-ubuntu12:
-  dockerfile: dockerfiles/Dockerfile.ubuntu-12
-  build: .
-  volumes:
-    - .:/octopass
-  environment:
-    DIST: precise
-  command: make deb12
+  #ubuntu16:
+  #  dockerfile: dockerfiles/Dockerfile.ubuntu-16
+  #  build: .
+  #  volumes:
+  #    - .:/octopass
+  #  environment:
+  #    DIST: xenial
+  #  command: make deb
+  #ubuntu14:
+  #  dockerfile: dockerfiles/Dockerfile.ubuntu-14
+  #  build: .
+  #  volumes:
+  #    - .:/octopass
+  #  environment:
+  #    DIST: trusty
+  #  command: make deb
+  #ubuntu12:
+  #  dockerfile: dockerfiles/Dockerfile.ubuntu-12
+  #  build: .
+  #  volumes:
+  #    - .:/octopass
+  #  environment:
+  #    DIST: precise
+  #  command: make deb12
 
 debian10:
   dockerfile: dockerfiles/Dockerfile.debian-10
@@ -82,11 +82,11 @@ debian9:
     DIST: stretch
     DEB_BUILD_OPTIONS: noautodbgsym
   command: make deb
-debian8:
-  dockerfile: dockerfiles/Dockerfile.debian-8
-  build: .
-  volumes:
-    - .:/octopass
-  environment:
-    DIST: jessie
-  command: make deb
+  #debian8:
+  #  dockerfile: dockerfiles/Dockerfile.debian-8
+  #  build: .
+  #  volumes:
+  #    - .:/octopass
+  #  environment:
+  #    DIST: jessie
+  #  command: make deb

--- a/nss_octopass-group.c
+++ b/nss_octopass-group.c
@@ -70,7 +70,6 @@ enum nss_status _nss_octopass_setgrent_locked(int stayopen)
   int status = octopass_members(&con, &res);
 
   if (status != 0) {
-    free(res.data);
     if (con.syslog) {
       syslog(LOG_INFO, "%s[L%d] -- status: %s", __func__, __LINE__, "UNAVAIL");
     }
@@ -224,7 +223,6 @@ enum nss_status _nss_octopass_getgrgid_r_locked(gid_t gid, struct group *result,
   int status = octopass_members(&con, &res);
 
   if (status != 0) {
-    free(res.data);
     *errnop = ENOENT;
     if (con.syslog) {
       syslog(LOG_INFO, "%s[L%d] -- status: %s", __func__, __LINE__, "UNAVAIL");
@@ -308,7 +306,6 @@ enum nss_status _nss_octopass_getgrnam_r_locked(const char *name, struct group *
   int status = octopass_members(&con, &res);
 
   if (status != 0) {
-    free(res.data);
     *errnop = ENOENT;
     if (con.syslog) {
       syslog(LOG_INFO, "%s[L%d] -- status: %s", __func__, __LINE__, "UNAVAIL");

--- a/nss_octopass-passwd.c
+++ b/nss_octopass-passwd.c
@@ -77,7 +77,6 @@ enum nss_status _nss_octopass_setpwent_locked(int stayopen)
   int status = octopass_members(&con, &res);
 
   if (status != 0) {
-    free(res.data);
     if (con.syslog) {
       syslog(LOG_INFO, "%s[L%d] -- status: %s", __func__, __LINE__, "UNAVAIL");
     }
@@ -227,7 +226,6 @@ enum nss_status _nss_octopass_getpwuid_r_locked(uid_t uid, struct passwd *result
   int status = octopass_members(&con, &res);
 
   if (status != 0) {
-    free(res.data);
     *errnop = ENOENT;
     if (con.syslog) {
       syslog(LOG_INFO, "%s[L%d] -- status: %s", __func__, __LINE__, "UNAVAIL");
@@ -310,7 +308,6 @@ enum nss_status _nss_octopass_getpwnam_r_locked(const char *name, struct passwd 
   int status = octopass_members(&con, &res);
 
   if (status != 0) {
-    free(res.data);
     *errnop = ENOENT;
     if (con.syslog) {
       syslog(LOG_INFO, "%s[L%d] -- status: %s", __func__, __LINE__, "UNAVAIL");

--- a/nss_octopass-shadow.c
+++ b/nss_octopass-shadow.c
@@ -70,7 +70,6 @@ enum nss_status _nss_octopass_setspent_locked(int stayopen)
   int status = octopass_members(&con, &res);
 
   if (status != 0) {
-    free(res.data);
     if (con.syslog) {
       syslog(LOG_INFO, "%s[L%d] -- status: %s", __func__, __LINE__, "UNAVAIL");
     }
@@ -205,7 +204,6 @@ enum nss_status _nss_octopass_getspnam_r_locked(const char *name, struct spwd *r
   int status = octopass_members(&con, &res);
 
   if (status != 0) {
-    free(res.data);
     *errnop = ENOENT;
     if (con.syslog) {
       syslog(LOG_INFO, "%s[L%d] -- status: %s", __func__, __LINE__, "UNAVAIL");

--- a/octopass.h
+++ b/octopass.h
@@ -35,7 +35,7 @@
 #include <regex.h>
 #include <unistd.h>
 
-#define OCTOPASS_VERSION "0.7.0"
+#define OCTOPASS_VERSION "0.7.1"
 #define OCTOPASS_VERSION_WITH_NAME "octopass/" OCTOPASS_VERSION
 #ifndef OCTOPASS_CONFIG_FILE
 #define OCTOPASS_CONFIG_FILE "/etc/octopass.conf"

--- a/rpm/octopass.spec
+++ b/rpm/octopass.spec
@@ -1,6 +1,6 @@
 Summary:          Management linux user and authentication with team or collaborator on Github.
 Name:             octopass
-Version:          0.7.0
+Version:          0.7.1
 Release:          1
 License:          GPLv3
 URL:              https://github.com/linyows/octopass
@@ -73,6 +73,8 @@ fi
 %{_datadir}/selinux/packages/%{name}/%{name}.pp
 
 %changelog
+* Thu Apr 27 2021 linyows <linyows@gmail.com> - 0.7.1-1
+- Bugfixes
 * Fri Jun 21 2019 linyows <linyows@gmail.com> - 0.7.0-1
 - Resolve a problem of cache file permission
 * Mon Oct 22 2018 linyows <linyows@gmail.com> - 0.6.0-1


### PR DESCRIPTION
I received the following report from @buty4649.


coredump:

```log
Stack trace of thread 655:
#0  0x00007efc27954870 __GI___libc_free (libc.so.6 + 0x9d870)
#1  0x00007efc252ac849 _nss_octopass_setgrent_locked (libnss_octopass.so.2 + 0x8849)
#2  0x00007efc252ac9ae _nss_octopass_setgrent (libnss_octopass.so.2 + 0x89ae)
```

syslog:

```sh
$ sudo grep octopass /var/log/syslog | grep 655
Apr 27 14:00:35 octopass[655]: config {endpoint: https://api.github.com/, token: ************ REDACTED ************, organization: foo, team: foo, owner: foo, repository: , permission:  syslog: 1, uid_starts: 2000, gid: 2000, group_name: foo, home: /home/%s, shell: /bin/bash, cache: 500}
Apr 27 14:00:35 octopass[655]: _nss_octopass_setgrent_locked[L68] -- stayopen: 623561097
Apr 27 14:00:35 octopass[655]: use cache: /var/cache/octopass/0/https%3A%2F%2Fapi.github.com%2Forgs%2Ffoo%2Fteams%3Fper_page%3D100-3b40d6
Apr 27 14:00:35 octopass[655]: team not found: foo
Apr 27 14:00:35 systemd-coredump[658]: Process 655 ((resolved)) of user 0 dumped core.#012#012Stack trace of thread 655:#012#0  0x00007efc27954870 __GI___libc_free (libc.so.6 + 0x9d870)#012#1  0x00007efc252ac849 _nss_octopass_setgrent_locked (libnss_octopass.so.2 + 0x8849)#012#2  0x00007efc252ac9ae _nss_octopass_setgrent (libnss_octopass.so.2 + 0x89ae)#012#3  0x00007efc27998e69 compat_call (libc.so.6 + 0xe1e69)#012#4  0x00007efc279992b9 internal_getgrouplist (libc.so.6 + 0xe22b9)#012#5  0x00007efc279994cf initgroups (libc.so.6 + 0xe24cf)#012#6  0x000055f6c010121b n/a (systemd + 0x4121b)#012#7  0x000055f6c0190562 n/a (systemd + 0xd0562)#012#8  0x000055f6c0159846 n/a (systemd + 0x99846)#012#9  0x000055f6c015e2d5 n/a (systemd + 0x9e2d5)#012#10 0x000055f6c015e888 n/a (systemd + 0x9e888)#012#11 0x000055f6c0186b2c n/a (systemd + 0xc6b2c)#012#12 0x000055f6c016bf3a n/a (systemd + 0xabf3a)#012#13 0x00007efc276d8382 n/a (libsystemd-shared-245.so + 0x74382)#012#14 0x00007efc276d87a1 sd_event_dispatch (libsystemd-shared-245.so + 0x747a1)#012#15 0x00007efc276da1d8 sd_event_run (libsystemd-shared-245.so + 0x761d8)#012#16 0x000055f6c01a6b14 n/a (systemd + 0xe6b14)#012#17 0x000055f6c00f83f3 n/a (systemd + 0x383f3)#012#18 0x00007efc278de0b3 __libc_start_main (libc.so.6 + 0x270b3)#012#19 0x000055f6c00f968e n/a (systemd + 0x3968e)
```

@buty4649 says: It seems that nothing is assigned to res.data when returning with L586:
https://github.com/linyows/octopass/blob/4fa12c44104838953cfac3b887a5a903d5ba3957/octopass.c#L586