### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  # Dependabot has no zig ecosystem, so build.zig.zon is not covered here.
+  # The website is managed by hand; only security updates are wanted, and
+  # those are delivered regardless of this file.
+  - package-ecosystem: npm
+    directory: /website
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Adds `.github/dependabot.yml` with a weekly schedule.

## What it covers

- **github-actions** — weekly version updates for the actions used in `.github/workflows`.

## What it does not cover

- **zig** — Dependabot has no `zig` package ecosystem, so `build.zig.zon` cannot be watched. See [dependabot-core#8166](https://github.com/dependabot/dependabot-core/issues/8166), open since 2023. `.dependencies` is currently empty anyway.
- **npm (`/website`)** — declared with `open-pull-requests-limit: 0` so version update PRs are turned off, making the intent explicit in the file rather than implicit by omission. Security updates are delivered regardless of this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)