### PR TITLE
Bump Zig to 0.16.0 to fix the macOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@e7d1537c378b83b8049f65dda471d87a2f7b2df2 # v2.2.0
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run tests
         run: zig build test
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@e7d1537c378b83b8049f65dda471d87a2f7b2df2 # v2.2.0
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Check formatting
         run: zig fmt --check src/

--- a/.github/workflows/end-to-end-test.yml
+++ b/.github/workflows/end-to-end-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@e7d1537c378b83b8049f65dda471d87a2f7b2df2 # v2.2.0
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build with cross compile
         run: zig build cross

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@e7d1537c378b83b8049f65dda471d87a2f7b2df2 # v2.2.0
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Update version from tag
         id: version

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,7 @@ sudo apt-get install octopass
 **ソースからビルド：**
 
 ```bash
-# Zig 0.15+ が必要
+# Zig 0.16+ が必要
 zig build -Doptimize=ReleaseSafe
 
 # NSS ライブラリをインストール

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo apt-get install octopass
 **Build from source:**
 
 ```bash
-# Requires Zig 0.15+
+# Requires Zig 0.16+
 zig build -Doptimize=ReleaseSafe
 
 # Install the NSS library

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .octopass,
     .version = "0.0.0-dev",
     .fingerprint = 0xb2529f754024d56c,
-    .minimum_zig_version = "0.14.0",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -15,6 +15,7 @@ pub const fallback_cache_dir = "/tmp/octopass";
 
 pub const Cache = struct {
     allocator: Allocator,
+    io: std.Io,
     cache_dir: []const u8,
     ttl_seconds: i64,
     enabled: bool,
@@ -23,10 +24,10 @@ pub const Cache = struct {
     const Self = @This();
     const HmacSha256 = std.crypto.auth.hmac.sha2.HmacSha256;
 
-    pub fn init(allocator: Allocator, cache_dir: []const u8, ttl_seconds: i64, token: []const u8) Self {
+    pub fn init(allocator: Allocator, io: std.Io, cache_dir: []const u8, ttl_seconds: i64, token: []const u8) Self {
         // Check if cache_dir exists, fallback to /tmp/octopass if not
         const actual_cache_dir = blk: {
-            std.fs.accessAbsolute(cache_dir, .{}) catch {
+            std.Io.Dir.accessAbsolute(io, cache_dir, .{}) catch {
                 break :blk fallback_cache_dir;
             };
             break :blk cache_dir;
@@ -34,6 +35,7 @@ pub const Cache = struct {
 
         return .{
             .allocator = allocator,
+            .io = io,
             .cache_dir = actual_cache_dir,
             .ttl_seconds = ttl_seconds,
             .enabled = ttl_seconds > 0,
@@ -59,13 +61,13 @@ pub const Cache = struct {
     pub fn get(self: *Self, key: []const u8) ?[]const u8 {
         if (!self.enabled) return null;
 
-        const file = std.fs.openFileAbsolute(key, .{}) catch return null;
-        defer file.close();
+        const file = std.Io.Dir.openFileAbsolute(self.io, key, .{}) catch return null;
+        defer file.close(self.io);
 
         // Check file modification time
-        const stat = file.stat() catch return null;
-        const mtime_sec = @divFloor(stat.mtime, std.time.ns_per_s);
-        const now = std.time.timestamp();
+        const stat = file.stat(self.io) catch return null;
+        const mtime_sec = stat.mtime.toSeconds();
+        const now = std.Io.Timestamp.now(self.io, .real).toSeconds();
 
         if (now - mtime_sec > self.ttl_seconds) {
             // Cache expired
@@ -73,7 +75,12 @@ pub const Cache = struct {
         }
 
         // Read file content
-        const content = file.readToEndAlloc(self.allocator, types.max_buffer_size) catch return null;
+        var read_buf: [4096]u8 = undefined;
+        var file_reader = file.reader(self.io, &read_buf);
+        const content = file_reader.interface.allocRemaining(
+            self.allocator,
+            .limited(types.max_buffer_size),
+        ) catch return null;
 
         // Verify signature: first 64 chars are hex signature, then newline, then data
         if (content.len < 66) { // 64 hex chars + newline + at least 1 byte data
@@ -113,19 +120,21 @@ pub const Cache = struct {
         const dir_path = key[0..dir_end];
 
         // Create directory structure with 0o755 permissions
-        try ensureDirectory(dir_path);
+        try ensureDirectory(self.io, dir_path);
 
         // Compute HMAC signature
         const signature = self.computeHmac(data);
 
         // Write file with 0o666 permissions
-        const file = std.fs.createFileAbsolute(key, .{ .mode = 0o666 }) catch return error.WriteFileFailed;
-        defer file.close();
+        const file = std.Io.Dir.createFileAbsolute(self.io, key, .{
+            .permissions = .default_file,
+        }) catch return error.WriteFileFailed;
+        defer file.close(self.io);
 
         // Write signature + newline + data
-        file.writeAll(&signature) catch return error.WriteFileFailed;
-        file.writeAll("\n") catch return error.WriteFileFailed;
-        file.writeAll(data) catch return error.WriteFileFailed;
+        file.writeStreamingAll(self.io, &signature) catch return error.WriteFileFailed;
+        file.writeStreamingAll(self.io, "\n") catch return error.WriteFileFailed;
+        file.writeStreamingAll(self.io, data) catch return error.WriteFileFailed;
     }
 
     /// Compute HMAC-SHA256 signature and return as hex string
@@ -151,13 +160,12 @@ pub const Cache = struct {
 
     /// Invalidate cache entry
     pub fn invalidate(self: *Self, key: []const u8) void {
-        _ = self;
-        std.fs.deleteFileAbsolute(key) catch {};
+        std.Io.Dir.deleteFileAbsolute(self.io, key) catch {};
     }
 
     /// Clear all cache
     pub fn clear(self: *Self) void {
-        std.fs.deleteTreeAbsolute(self.cache_dir) catch {};
+        std.Io.Dir.cwd().deleteTree(self.io, self.cache_dir) catch {};
     }
 };
 
@@ -172,8 +180,8 @@ fn setPermissions(path: []const u8, mode: std.c.mode_t) void {
 }
 
 /// Ensure directory exists with 0o755 permissions
-fn ensureDirectory(path: []const u8) !void {
-    std.fs.makeDirAbsolute(path) catch |err| {
+fn ensureDirectory(io: std.Io, path: []const u8) !void {
+    std.Io.Dir.createDirAbsolute(io, path, .default_dir) catch |err| {
         switch (err) {
             error.PathAlreadyExists => {
                 // Ensure permissions are correct
@@ -184,8 +192,8 @@ fn ensureDirectory(path: []const u8) !void {
                 // Parent directory doesn't exist, create recursively
                 if (std.mem.lastIndexOf(u8, path, "/")) |parent_end| {
                     if (parent_end > 0) {
-                        try ensureDirectory(path[0..parent_end]);
-                        std.fs.makeDirAbsolute(path) catch |e| {
+                        try ensureDirectory(io, path[0..parent_end]);
+                        std.Io.Dir.createDirAbsolute(io, path, .default_dir) catch |e| {
                             if (e != error.PathAlreadyExists) return e;
                         };
                         setPermissions(path, 0o755);
@@ -240,7 +248,7 @@ test "urlEncode safe chars" {
 
 test "Cache init" {
     const allocator = std.testing.allocator;
-    const cache = Cache.init(allocator, "/tmp/cache", 300, "test_token");
+    const cache = Cache.init(allocator, std.testing.io, "/tmp/cache", 300, "test_token");
 
     try std.testing.expect(cache.enabled);
     try std.testing.expectEqual(@as(i64, 300), cache.ttl_seconds);
@@ -249,14 +257,14 @@ test "Cache init" {
 
 test "Cache disabled when ttl is 0" {
     const allocator = std.testing.allocator;
-    const cache = Cache.init(allocator, "/tmp/cache", 0, "test_token");
+    const cache = Cache.init(allocator, std.testing.io, "/tmp/cache", 0, "test_token");
 
     try std.testing.expect(!cache.enabled);
 }
 
 test "computeHmac produces correct hex output" {
     const allocator = std.testing.allocator;
-    var cache = Cache.init(allocator, "/tmp/cache", 300, "secret_key");
+    var cache = Cache.init(allocator, std.testing.io, "/tmp/cache", 300, "secret_key");
 
     const signature = cache.computeHmac("test data");
     try std.testing.expectEqual(@as(usize, 64), signature.len);
@@ -269,7 +277,7 @@ test "computeHmac produces correct hex output" {
 
 test "verifyHmac validates correct signature" {
     const allocator = std.testing.allocator;
-    var cache = Cache.init(allocator, "/tmp/cache", 300, "secret_key");
+    var cache = Cache.init(allocator, std.testing.io, "/tmp/cache", 300, "secret_key");
 
     const data = "test data";
     const signature = cache.computeHmac(data);
@@ -279,7 +287,7 @@ test "verifyHmac validates correct signature" {
 
 test "verifyHmac rejects incorrect signature" {
     const allocator = std.testing.allocator;
-    var cache = Cache.init(allocator, "/tmp/cache", 300, "secret_key");
+    var cache = Cache.init(allocator, std.testing.io, "/tmp/cache", 300, "secret_key");
 
     const data = "test data";
     const wrong_signature = "0000000000000000000000000000000000000000000000000000000000000000";
@@ -289,7 +297,7 @@ test "verifyHmac rejects incorrect signature" {
 
 test "verifyHmac rejects tampered data" {
     const allocator = std.testing.allocator;
-    var cache = Cache.init(allocator, "/tmp/cache", 300, "secret_key");
+    var cache = Cache.init(allocator, std.testing.io, "/tmp/cache", 300, "secret_key");
 
     const original_data = "test data";
     const signature = cache.computeHmac(original_data);
@@ -301,7 +309,7 @@ test "verifyHmac rejects tampered data" {
 test "generateKey produces shared path without euid" {
     const allocator = std.testing.allocator;
     // Use /tmp which always exists
-    var cache = Cache.init(allocator, "/tmp", 300, "test_token");
+    var cache = Cache.init(allocator, std.testing.io, "/tmp", 300, "test_token");
 
     const key = try cache.generateKey("https://api.github.com/test", "abc123");
     defer allocator.free(key);

--- a/src/cache.zig
+++ b/src/cache.zig
@@ -202,7 +202,7 @@ fn ensureDirectory(path: []const u8) !void {
 
 /// URL encode a string for safe filename
 fn urlEncode(allocator: Allocator, input: []const u8) ![]const u8 {
-    var result = std.ArrayListUnmanaged(u8){};
+    var result = std.ArrayList(u8).empty;
     errdefer result.deinit(allocator);
 
     for (input) |char| {

--- a/src/config.zig
+++ b/src/config.zig
@@ -198,7 +198,7 @@ pub const Config = struct {
 
     /// Parse SharedUsers array format: [ "user1", "user2" ]
     fn parseSharedUsers(self: *Self, value: []const u8) !void {
-        var users = std.ArrayListUnmanaged([]const u8){};
+        var users = std.ArrayList([]const u8).empty;
         errdefer {
             for (users.items) |user| {
                 self.allocator.free(user);

--- a/src/config.zig
+++ b/src/config.zig
@@ -86,19 +86,21 @@ pub const Config = struct {
     }
 
     /// Load configuration from file
-    pub fn load(allocator: Allocator, filename: []const u8) !Self {
+    pub fn load(allocator: Allocator, io: std.Io, filename: []const u8) !Self {
         var config = Self.init(allocator);
         errdefer config.deinit();
 
-        const file = std.fs.openFileAbsolute(filename, .{}) catch |err| {
+        const content = std.Io.Dir.cwd().readFileAlloc(
+            io,
+            filename,
+            allocator,
+            .limited(types.max_buffer_size),
+        ) catch |err| {
             if (err == error.FileNotFound) {
                 return error.ConfigNotFound;
             }
             return err;
         };
-        defer file.close();
-
-        const content = try file.readToEndAlloc(allocator, types.max_buffer_size);
         defer allocator.free(content);
 
         try config.parse(content);
@@ -278,10 +280,19 @@ pub const Config = struct {
         }
     }
 
+    /// Read the process environment through libc.
+    ///
+    /// `std.posix.getenv` is gone in Zig 0.16, and the NSS entry points have no
+    /// `std.process.Init` to take an environment from, so go to libc directly.
+    /// Every artifact here links libc.
+    fn processEnviron() std.process.Environ {
+        return .{ .block = .{ .slice = @ptrCast(std.mem.sliceTo(std.c.environ, null)) } };
+    }
+
     /// Override config values from environment variables
     fn overrideFromEnv(self: *Self) !void {
         // Provider must be set first as it affects how other env vars are interpreted
-        if (std.posix.getenv("OCTOPASS_PROVIDER")) |value| {
+        if (processEnviron().getPosix("OCTOPASS_PROVIDER")) |value| {
             try self.setValue("Provider", value);
         }
 
@@ -300,7 +311,7 @@ pub const Config = struct {
         };
 
         for (env_vars) |ev| {
-            if (std.posix.getenv(ev.env)) |value| {
+            if (processEnviron().getPosix(ev.env)) |value| {
                 try self.setValue(ev.field, value);
             }
         }

--- a/src/github.zig
+++ b/src/github.zig
@@ -16,17 +16,19 @@ const user_url = "{s}user";
 
 pub const GitHubProvider = struct {
     allocator: Allocator,
+    io: std.Io,
     config: *const config_mod.Config,
     cache: cache_mod.Cache,
     logger: *log.Logger,
 
     const Self = @This();
 
-    pub fn init(allocator: Allocator, config: *const config_mod.Config, logger: *log.Logger) Self {
+    pub fn init(allocator: Allocator, io: std.Io, config: *const config_mod.Config, logger: *log.Logger) Self {
         return .{
             .allocator = allocator,
+            .io = io,
             .config = config,
-            .cache = cache_mod.Cache.init(allocator, types.default_cache_dir, config.cache, config.token),
+            .cache = cache_mod.Cache.init(allocator, io, types.default_cache_dir, config.cache, config.token),
             .logger = logger,
         };
     }
@@ -173,7 +175,7 @@ pub const GitHubProvider = struct {
     fn httpGetNoCache(self: *Self, allocator: Allocator, url: []const u8, custom_token: ?[]const u8) types.ProviderError![]const u8 {
         self.logger.info("http get: {s}", .{url});
 
-        var client = http.Client{ .allocator = allocator };
+        var client = http.Client{ .allocator = allocator, .io = self.io };
         defer client.deinit();
 
         const token = custom_token orelse self.config.token;
@@ -214,7 +216,7 @@ pub const GitHubProvider = struct {
         var decompress: http.Decompress = undefined;
         var decompress_buf: [std.compress.flate.max_window_len]u8 = undefined;
         const reader = response.readerDecompressing(&transfer_buf, &decompress, &decompress_buf);
-        const body = reader.allocRemaining(allocator, std.io.Limit.limited(types.max_buffer_size)) catch {
+        const body = reader.allocRemaining(allocator, std.Io.Limit.limited(types.max_buffer_size)) catch {
             return types.ProviderError.NetworkError;
         };
 
@@ -383,7 +385,7 @@ test "GitHubProvider init" {
     defer config.deinit();
 
     var logger = log.Logger.init("test", false);
-    var github = GitHubProvider.init(allocator, &config, &logger);
+    var github = GitHubProvider.init(allocator, std.testing.io, &config, &logger);
     defer github.deinit();
 }
 
@@ -394,7 +396,7 @@ test "parseUsersJson" {
     defer config.deinit();
 
     var logger = log.Logger.init("test", false);
-    var github = GitHubProvider.init(allocator, &config, &logger);
+    var github = GitHubProvider.init(allocator, std.testing.io, &config, &logger);
     defer github.deinit();
 
     const json_data =
@@ -421,7 +423,7 @@ test "parseTeamsJson" {
     defer config.deinit();
 
     var logger = log.Logger.init("test", false);
-    var github = GitHubProvider.init(allocator, &config, &logger);
+    var github = GitHubProvider.init(allocator, std.testing.io, &config, &logger);
     defer github.deinit();
 
     const json_data =
@@ -447,7 +449,7 @@ test "extractKeys" {
     defer config.deinit();
 
     var logger = log.Logger.init("test", false);
-    var github = GitHubProvider.init(allocator, &config, &logger);
+    var github = GitHubProvider.init(allocator, std.testing.io, &config, &logger);
     defer github.deinit();
 
     const json_data =

--- a/src/github.zig
+++ b/src/github.zig
@@ -234,7 +234,7 @@ pub const GitHubProvider = struct {
         const root = parsed.value;
         if (root != .array) return types.ProviderError.JsonParseError;
 
-        var users = std.ArrayListUnmanaged(types.User){};
+        var users = std.ArrayList(types.User).empty;
         errdefer {
             for (users.items) |*user| {
                 user.deinit(allocator);
@@ -272,7 +272,7 @@ pub const GitHubProvider = struct {
 
         const required_permission = self.config.permission.toString();
 
-        var users = std.ArrayListUnmanaged(types.User){};
+        var users = std.ArrayList(types.User).empty;
         errdefer {
             for (users.items) |*user| {
                 user.deinit(allocator);
@@ -318,7 +318,7 @@ pub const GitHubProvider = struct {
         const root = parsed.value;
         if (root != .array) return types.ProviderError.JsonParseError;
 
-        var teams = std.ArrayListUnmanaged(types.Team){};
+        var teams = std.ArrayList(types.Team).empty;
         errdefer {
             for (teams.items) |*team| {
                 team.deinit(allocator);
@@ -358,7 +358,7 @@ pub const GitHubProvider = struct {
         const root = parsed.value;
         if (root != .array) return types.ProviderError.JsonParseError;
 
-        var keys = std.ArrayListUnmanaged(u8){};
+        var keys = std.ArrayList(u8).empty;
         errdefer keys.deinit(allocator);
 
         for (root.array.items) |item| {

--- a/src/gitlab.zig
+++ b/src/gitlab.zig
@@ -285,7 +285,7 @@ pub const GitLabProvider = struct {
         const root = parsed.value;
         if (root != .array) return types.ProviderError.JsonParseError;
 
-        var users = std.ArrayListUnmanaged(types.User){};
+        var users = std.ArrayList(types.User).empty;
         errdefer {
             for (users.items) |*user| {
                 user.deinit(allocator);
@@ -323,7 +323,7 @@ pub const GitLabProvider = struct {
 
         const required_access_level = self.config.permission.toGitLabAccessLevel();
 
-        var users = std.ArrayListUnmanaged(types.User){};
+        var users = std.ArrayList(types.User).empty;
         errdefer {
             for (users.items) |*user| {
                 user.deinit(allocator);
@@ -369,7 +369,7 @@ pub const GitLabProvider = struct {
         const root = parsed.value;
         if (root != .array) return types.ProviderError.JsonParseError;
 
-        var keys = std.ArrayListUnmanaged(u8){};
+        var keys = std.ArrayList(u8).empty;
         errdefer keys.deinit(allocator);
 
         for (root.array.items) |item| {
@@ -388,7 +388,7 @@ pub const GitLabProvider = struct {
 
 /// URL encode path segments (replace '/' with '%2F')
 fn urlEncodePath(allocator: Allocator, path: []const u8) ![]const u8 {
-    var result = std.ArrayListUnmanaged(u8){};
+    var result = std.ArrayList(u8).empty;
     errdefer result.deinit(allocator);
 
     for (path) |c| {

--- a/src/gitlab.zig
+++ b/src/gitlab.zig
@@ -17,17 +17,19 @@ const current_user_url = "{s}user";
 
 pub const GitLabProvider = struct {
     allocator: Allocator,
+    io: std.Io,
     config: *const config_mod.Config,
     cache: cache_mod.Cache,
     logger: *log.Logger,
 
     const Self = @This();
 
-    pub fn init(allocator: Allocator, config: *const config_mod.Config, logger: *log.Logger) Self {
+    pub fn init(allocator: Allocator, io: std.Io, config: *const config_mod.Config, logger: *log.Logger) Self {
         return .{
             .allocator = allocator,
+            .io = io,
             .config = config,
-            .cache = cache_mod.Cache.init(allocator, types.default_cache_dir, config.cache, config.token),
+            .cache = cache_mod.Cache.init(allocator, io, types.default_cache_dir, config.cache, config.token),
             .logger = logger,
         };
     }
@@ -227,7 +229,7 @@ pub const GitLabProvider = struct {
     fn httpGetNoCache(self: *Self, allocator: Allocator, url: []const u8, custom_token: ?[]const u8) types.ProviderError![]const u8 {
         self.logger.info("http get: {s}", .{url});
 
-        var client = http.Client{ .allocator = allocator };
+        var client = http.Client{ .allocator = allocator, .io = self.io };
         defer client.deinit();
 
         const token = custom_token orelse self.config.token;
@@ -265,7 +267,7 @@ pub const GitLabProvider = struct {
         var decompress: http.Decompress = undefined;
         var decompress_buf: [std.compress.flate.max_window_len]u8 = undefined;
         const reader = response.readerDecompressing(&transfer_buf, &decompress, &decompress_buf);
-        const body = reader.allocRemaining(allocator, std.io.Limit.limited(types.max_buffer_size)) catch {
+        const body = reader.allocRemaining(allocator, std.Io.Limit.limited(types.max_buffer_size)) catch {
             return types.ProviderError.NetworkError;
         };
 
@@ -410,7 +412,7 @@ test "GitLabProvider init" {
     defer config.deinit();
 
     var logger = log.Logger.init("test", false);
-    var gitlab = GitLabProvider.init(allocator, &config, &logger);
+    var gitlab = GitLabProvider.init(allocator, std.testing.io, &config, &logger);
     defer gitlab.deinit();
 }
 
@@ -437,7 +439,7 @@ test "parseUsersJson" {
     defer config.deinit();
 
     var logger = log.Logger.init("test", false);
-    var gitlab = GitLabProvider.init(allocator, &config, &logger);
+    var gitlab = GitLabProvider.init(allocator, std.testing.io, &config, &logger);
     defer gitlab.deinit();
 
     const json_data =
@@ -465,7 +467,7 @@ test "parseMembersWithPermission" {
     config.permission = .write; // access_level >= 30
 
     var logger = log.Logger.init("test", false);
-    var gitlab = GitLabProvider.init(allocator, &config, &logger);
+    var gitlab = GitLabProvider.init(allocator, std.testing.io, &config, &logger);
     defer gitlab.deinit();
 
     const json_data =
@@ -493,7 +495,7 @@ test "extractKeys" {
     defer config.deinit();
 
     var logger = log.Logger.init("test", false);
-    var gitlab = GitLabProvider.init(allocator, &config, &logger);
+    var gitlab = GitLabProvider.init(allocator, std.testing.io, &config, &logger);
     defer gitlab.deinit();
 
     const json_data =

--- a/src/main.zig
+++ b/src/main.zig
@@ -28,27 +28,30 @@ const Command = enum {
     keys, // Default: get public keys for a user
 };
 
+/// Write raw bytes to stdout
+fn writeOut(io: std.Io, bytes: []const u8) void {
+    std.Io.File.stdout().writeStreamingAll(io, bytes) catch return;
+}
+
 /// Write formatted output to stdout
-fn writeStdout(comptime fmt: []const u8, args: anytype) void {
+fn writeStdout(io: std.Io, comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
     const result = std.fmt.bufPrint(&buf, fmt, args) catch return;
-    _ = std.posix.write(std.posix.STDOUT_FILENO, result) catch return;
+    writeOut(io, result);
 }
 
 /// Write error message to stderr
-fn writeError(comptime fmt: []const u8, args: anytype) void {
+fn writeError(io: std.Io, comptime fmt: []const u8, args: anytype) void {
     var buf: [4096]u8 = undefined;
     const result = std.fmt.bufPrint(&buf, ANSI_RED ++ "Error: " ++ ANSI_RESET ++ fmt, args) catch return;
-    _ = std.posix.write(std.posix.STDERR_FILENO, result) catch return;
+    std.Io.File.stderr().writeStreamingAll(io, result) catch return;
 }
 
-pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+pub fn main(init: std.process.Init) !void {
+    const allocator = init.gpa;
+    const io = init.io;
 
-    const args = try std.process.argsAlloc(allocator);
-    defer std.process.argsFree(allocator, args);
+    const args = try init.minimal.args.toSlice(init.arena.allocator());
 
     // Parse global options first
     var config_path: []const u8 = types.default_config_file;
@@ -59,17 +62,17 @@ pub fn main() !void {
         const arg = args[arg_index];
         if (std.mem.eql(u8, arg, "-c") or std.mem.eql(u8, arg, "--config")) {
             if (arg_index + 1 >= args.len) {
-                writeError("Missing argument for {s}\n", .{arg});
+                writeError(io, "Missing argument for {s}\n", .{arg});
                 std.process.exit(2);
             }
             const path_arg = args[arg_index + 1];
             // Convert relative path to absolute path
             if (!std.fs.path.isAbsolute(path_arg)) {
-                const cwd = std.fs.cwd();
-                config_path = cwd.realpath(path_arg, &config_path_buf) catch |err| {
-                    writeError("Failed to resolve config path '{s}': {}\n", .{ path_arg, err });
+                const len = std.Io.Dir.cwd().realPathFile(io, path_arg, &config_path_buf) catch |err| {
+                    writeError(io, "Failed to resolve config path '{s}': {}\n", .{ path_arg, err });
                     std.process.exit(2);
                 };
+                config_path = config_path_buf[0..len];
             } else {
                 config_path = path_arg;
             }
@@ -80,7 +83,7 @@ pub fn main() !void {
     }
 
     if (arg_index >= args.len) {
-        printUsage();
+        printUsage(io);
         std.process.exit(2);
     }
 
@@ -88,76 +91,76 @@ pub fn main() !void {
 
     // Check for help/version flags
     if (std.mem.eql(u8, arg1, "--help") or std.mem.eql(u8, arg1, "-h")) {
-        printUsage();
+        printUsage(io);
         std.process.exit(2);
     }
 
     if (std.mem.eql(u8, arg1, "--version") or std.mem.eql(u8, arg1, "-v")) {
-        printVersion();
+        printVersion(io);
         return;
     }
 
     // Parse command
     if (std.mem.eql(u8, arg1, "passwd")) {
         const key = if (arg_index + 1 < args.len) args[arg_index + 1] else null;
-        try runPasswd(allocator, config_path, key);
+        try runPasswd(allocator, io, config_path, key);
     } else if (std.mem.eql(u8, arg1, "group")) {
         const key = if (arg_index + 1 < args.len) args[arg_index + 1] else null;
-        try runGroup(allocator, config_path, key);
+        try runGroup(allocator, io, config_path, key);
     } else if (std.mem.eql(u8, arg1, "shadow")) {
         const key = if (arg_index + 1 < args.len) args[arg_index + 1] else null;
-        try runShadow(allocator, config_path, key);
+        try runShadow(allocator, io, config_path, key);
     } else if (std.mem.eql(u8, arg1, "pam")) {
-        const user = if (arg_index + 1 < args.len) args[arg_index + 1] else std.posix.getenv("PAM_USER");
+        const user = if (arg_index + 1 < args.len) args[arg_index + 1] else init.environ_map.get("PAM_USER");
         if (user == null) {
-            writeError("User is required\n", .{});
+            writeError(io, "User is required\n", .{});
             std.process.exit(2);
         }
-        const exit_code = try runPam(allocator, config_path, user.?);
+        const exit_code = try runPam(allocator, io, config_path, user.?);
         std.process.exit(exit_code);
     } else {
         // Default: treat as username and get public keys
-        try runKeys(allocator, config_path, arg1);
+        try runKeys(allocator, io, config_path, arg1);
     }
 }
 
-fn printVersion() void {
-    writeStdout("{s}\n", .{types.version_with_name});
+fn printVersion(io: std.Io) void {
+    writeStdout(io, "{s}\n", .{types.version_with_name});
 }
 
-fn printUsage() void {
+fn printUsage(io: std.Io) void {
     // Logo with green color
-    _ = std.posix.write(std.posix.STDOUT_FILENO, ANSI_GREEN) catch {};
-    _ = std.posix.write(std.posix.STDOUT_FILENO, logo) catch {};
-    _ = std.posix.write(std.posix.STDOUT_FILENO, ANSI_RESET) catch {};
+    writeOut(io, ANSI_GREEN);
+    writeOut(io, logo);
+    writeOut(io, ANSI_RESET);
 
     // Description with dim color
-    _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
-    _ = std.posix.write(std.posix.STDOUT_FILENO, ANSI_DIM) catch {};
-    _ = std.posix.write(std.posix.STDOUT_FILENO, desc) catch {};
-    _ = std.posix.write(std.posix.STDOUT_FILENO, ANSI_RESET) catch {};
+    writeOut(io, "\n");
+    writeOut(io, ANSI_DIM);
+    writeOut(io, desc);
+    writeOut(io, ANSI_RESET);
 
     // Usage
-    _ = std.posix.write(std.posix.STDOUT_FILENO, "\n") catch {};
-    _ = std.posix.write(std.posix.STDOUT_FILENO, usage) catch {};
+    writeOut(io, "\n");
+    writeOut(io, usage);
 }
 
-fn loadConfig(allocator: Allocator, config_path: []const u8) !config_mod.Config {
-    return config_mod.Config.load(allocator, config_path) catch |err| {
-        writeError("Failed to load config: {}\n", .{err});
+fn loadConfig(allocator: Allocator, io: std.Io, config_path: []const u8) !config_mod.Config {
+    return config_mod.Config.load(allocator, io, config_path) catch |err| {
+        writeError(io, "Failed to load config: {}\n", .{err});
         return err;
     };
 }
 
 /// Get public keys for a user (default command)
-fn runKeys(allocator: Allocator, config_path: []const u8, username: []const u8) !void {
-    var config = try loadConfig(allocator, config_path);
+fn runKeys(allocator: Allocator, io: std.Io, config_path: []const u8, username: []const u8) !void {
+    var config = try loadConfig(allocator, io, config_path);
     defer config.deinit();
 
     var logger = log.Logger.init("octopass", config.syslog);
     defer logger.close();
 
-    var provider = provider_mod.Provider.init(allocator, &config, &logger);
+    var provider = provider_mod.Provider.init(allocator, io, &config, &logger);
     defer provider.deinit();
 
     // Check if user is a shared user
@@ -165,7 +168,7 @@ fn runKeys(allocator: Allocator, config_path: []const u8, username: []const u8) 
         if (std.mem.eql(u8, username, shared_user)) {
             // Get all team members' keys for shared users
             const users = provider.getMembers(allocator) catch |err| {
-                writeError("Failed to get members: {}\n", .{err});
+                writeError(io, "Failed to get members: {}\n", .{err});
                 std.process.exit(1);
             };
             defer types.freeUsers(allocator, users);
@@ -173,7 +176,7 @@ fn runKeys(allocator: Allocator, config_path: []const u8, username: []const u8) 
             for (users) |user| {
                 const keys = provider.getUserKeys(allocator, user.login) catch continue;
                 defer allocator.free(keys);
-                _ = std.posix.write(std.posix.STDOUT_FILENO, keys) catch {};
+                writeOut(io, keys);
             }
             return;
         }
@@ -181,53 +184,47 @@ fn runKeys(allocator: Allocator, config_path: []const u8, username: []const u8) 
 
     // Get keys for specific user
     const keys = provider.getUserKeys(allocator, username) catch |err| {
-        writeError("Failed to get keys for {s}: {}\n", .{ username, err });
+        writeError(io, "Failed to get keys for {s}: {}\n", .{ username, err });
         std.process.exit(1);
     };
     defer allocator.free(keys);
 
-    _ = std.posix.write(std.posix.STDOUT_FILENO, keys) catch return;
+    writeOut(io, keys);
 }
 
 /// PAM authentication - read token from stdin
-fn runPam(allocator: Allocator, config_path: []const u8, username: []const u8) !u8 {
+fn runPam(allocator: Allocator, io: std.Io, config_path: []const u8, username: []const u8) !u8 {
     // Read token from stdin
-    const stdin = std.fs.File{ .handle = std.posix.STDIN_FILENO };
     var buf: [4096]u8 = undefined;
+    var stdin_reader = std.Io.File.stdin().readerStreaming(io, &buf);
 
-    var token_buf = std.ArrayList(u8).empty;
-    defer token_buf.deinit(allocator);
-
-    while (true) {
-        const n = stdin.read(&buf) catch {
-            writeError("Failed to read token from stdin\n", .{});
-            return 2;
-        };
-        if (n == 0) break;
-        token_buf.appendSlice(allocator, buf[0..n]) catch {
-            writeError("Out of memory\n", .{});
-            return 2;
-        };
-    }
+    const token_buf = stdin_reader.interface.allocRemaining(
+        allocator,
+        .limited(types.max_buffer_size),
+    ) catch {
+        writeError(io, "Failed to read token from stdin\n", .{});
+        return 2;
+    };
+    defer allocator.free(token_buf);
 
     // Trim newline
-    var token = token_buf.items;
+    var token = token_buf;
     if (token.len > 0 and token[token.len - 1] == '\n') {
         token = token[0 .. token.len - 1];
     }
 
     if (token.len == 0) {
-        writeError("Token is required\n", .{});
+        writeError(io, "Token is required\n", .{});
         return 2;
     }
 
-    var config = loadConfig(allocator, config_path) catch return 2;
+    var config = loadConfig(allocator, io, config_path) catch return 2;
     defer config.deinit();
 
     var logger = log.Logger.init("octopass", config.syslog);
     defer logger.close();
 
-    var provider = provider_mod.Provider.init(allocator, &config, &logger);
+    var provider = provider_mod.Provider.init(allocator, io, &config, &logger);
     defer provider.deinit();
 
     // Authenticate with token
@@ -243,18 +240,18 @@ fn runPam(allocator: Allocator, config_path: []const u8, username: []const u8) !
 }
 
 /// Display passwd entries
-fn runPasswd(allocator: Allocator, config_path: []const u8, key: ?[]const u8) !void {
-    var config = try loadConfig(allocator, config_path);
+fn runPasswd(allocator: Allocator, io: std.Io, config_path: []const u8, key: ?[]const u8) !void {
+    var config = try loadConfig(allocator, io, config_path);
     defer config.deinit();
 
     var logger = log.Logger.init("octopass", config.syslog);
     defer logger.close();
 
-    var provider = provider_mod.Provider.init(allocator, &config, &logger);
+    var provider = provider_mod.Provider.init(allocator, io, &config, &logger);
     defer provider.deinit();
 
     const users = provider.getMembers(allocator) catch |err| {
-        writeError("Failed to get members: {}\n", .{err});
+        writeError(io, "Failed to get members: {}\n", .{err});
         std.process.exit(1);
     };
     defer types.freeUsers(allocator, users);
@@ -268,32 +265,32 @@ fn runPasswd(allocator: Allocator, config_path: []const u8, key: ?[]const u8) !v
             for (users) |user| {
                 const user_uid = config.uid_starts + user.id;
                 if (user_uid == uid) {
-                    printPasswdEntry(&config, user);
+                    printPasswdEntry(io, &config, user);
                     return;
                 }
             }
         } else {
             // Find by name
             if (types.findUserByLogin(users, k)) |user| {
-                printPasswdEntry(&config, user.*);
+                printPasswdEntry(io, &config, user.*);
                 return;
             }
         }
     } else {
         // List all
         for (users) |user| {
-            printPasswdEntry(&config, user);
+            printPasswdEntry(io, &config, user);
         }
     }
 }
 
-fn printPasswdEntry(config: *const config_mod.Config, user: types.User) void {
+fn printPasswdEntry(io: std.Io, config: *const config_mod.Config, user: types.User) void {
     const uid = config.uid_starts + user.id;
 
     var home_buf: [256]u8 = undefined;
     const home = if (nss_common.simpleFormatHomePath(&home_buf, config.home, user.login)) |h| h else "/home/user";
 
-    writeStdout("{s}:x:{d}:{d}:managed by octopass:{s}:{s}\n", .{
+    writeStdout(io, "{s}:x:{d}:{d}:managed by octopass:{s}:{s}\n", .{
         user.login,
         uid,
         config.gid,
@@ -303,18 +300,18 @@ fn printPasswdEntry(config: *const config_mod.Config, user: types.User) void {
 }
 
 /// Display group entries
-fn runGroup(allocator: Allocator, config_path: []const u8, key: ?[]const u8) !void {
-    var config = try loadConfig(allocator, config_path);
+fn runGroup(allocator: Allocator, io: std.Io, config_path: []const u8, key: ?[]const u8) !void {
+    var config = try loadConfig(allocator, io, config_path);
     defer config.deinit();
 
     var logger = log.Logger.init("octopass", config.syslog);
     defer logger.close();
 
-    var provider = provider_mod.Provider.init(allocator, &config, &logger);
+    var provider = provider_mod.Provider.init(allocator, io, &config, &logger);
     defer provider.deinit();
 
     const users = provider.getMembers(allocator) catch |err| {
-        writeError("Failed to get members: {}\n", .{err});
+        writeError(io, "Failed to get members: {}\n", .{err});
         std.process.exit(1);
     };
     defer types.freeUsers(allocator, users);
@@ -333,29 +330,29 @@ fn runGroup(allocator: Allocator, config_path: []const u8, key: ?[]const u8) !vo
     }
 
     // Print group entry
-    writeStdout("{s}:x:{d}:", .{ group_name, config.gid });
+    writeStdout(io, "{s}:x:{d}:", .{ group_name, config.gid });
 
     // Print members
     for (users, 0..) |user, i| {
-        if (i > 0) writeStdout(",", .{});
-        writeStdout("{s}", .{user.login});
+        if (i > 0) writeStdout(io, ",", .{});
+        writeStdout(io, "{s}", .{user.login});
     }
-    writeStdout("\n", .{});
+    writeStdout(io, "\n", .{});
 }
 
 /// Display shadow entries
-fn runShadow(allocator: Allocator, config_path: []const u8, key: ?[]const u8) !void {
-    var config = try loadConfig(allocator, config_path);
+fn runShadow(allocator: Allocator, io: std.Io, config_path: []const u8, key: ?[]const u8) !void {
+    var config = try loadConfig(allocator, io, config_path);
     defer config.deinit();
 
     var logger = log.Logger.init("octopass", config.syslog);
     defer logger.close();
 
-    var provider = provider_mod.Provider.init(allocator, &config, &logger);
+    var provider = provider_mod.Provider.init(allocator, io, &config, &logger);
     defer provider.deinit();
 
     const users = provider.getMembers(allocator) catch |err| {
-        writeError("Failed to get members: {}\n", .{err});
+        writeError(io, "Failed to get members: {}\n", .{err});
         std.process.exit(1);
     };
     defer types.freeUsers(allocator, users);
@@ -365,25 +362,25 @@ fn runShadow(allocator: Allocator, config_path: []const u8, key: ?[]const u8) !v
         const is_number = std.fmt.parseInt(i64, k, 10) catch null;
 
         if (is_number != null) {
-            writeError("Invalid arguments: {s}\n", .{k});
+            writeError(io, "Invalid arguments: {s}\n", .{k});
             return;
         }
 
         // Find by name
         if (types.findUserByLogin(users, k)) |user| {
-            printShadowEntry(user.*);
+            printShadowEntry(io, user.*);
             return;
         }
     } else {
         // List all
         for (users) |user| {
-            printShadowEntry(user);
+            printShadowEntry(io, user);
         }
     }
 }
 
-fn printShadowEntry(user: types.User) void {
+fn printShadowEntry(io: std.Io, user: types.User) void {
     // Format: name:password:lastchg:min:max:warn:inactive:expire:reserved
     // Using !! for locked password and -1 for unset values
-    writeStdout("{s}:!!:-1:-1:-1:-1:-1:-1:\n", .{user.login});
+    writeStdout(io, "{s}:!!:-1:-1:-1:-1:-1:-1:\n", .{user.login});
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -195,7 +195,7 @@ fn runPam(allocator: Allocator, config_path: []const u8, username: []const u8) !
     const stdin = std.fs.File{ .handle = std.posix.STDIN_FILENO };
     var buf: [4096]u8 = undefined;
 
-    var token_buf = std.ArrayListUnmanaged(u8){};
+    var token_buf = std.ArrayList(u8).empty;
     defer token_buf.deinit(allocator);
 
     while (true) {

--- a/src/nss_common.zig
+++ b/src/nss_common.zig
@@ -47,7 +47,7 @@ pub const GlobalState = struct {
     pub fn loadConfig(self: *Self) !void {
         if (self.config != null) return;
 
-        self.config = config_mod.Config.load(self.allocator, types.default_config_file) catch |err| {
+        self.config = config_mod.Config.load(self.allocator, getIo(), types.default_config_file) catch |err| {
             self.logger.err("config load failed: {}", .{err});
             return error.ConfigNotFound;
         };
@@ -63,7 +63,7 @@ pub const GlobalState = struct {
 
         try self.loadConfig();
 
-        var provider = provider_mod.Provider.init(self.allocator, &self.config.?, &self.logger);
+        var provider = provider_mod.Provider.init(self.allocator, getIo(), &self.config.?, &self.logger);
         defer provider.deinit();
 
         self.users = provider.getMembers(self.allocator) catch |err| {
@@ -76,10 +76,30 @@ pub const GlobalState = struct {
 };
 
 /// Thread-safe mutex for NSS operations
-pub var nss_mutex: std.Thread.Mutex = .{};
+pub var nss_mutex: std.Io.Mutex = .init;
+
+pub fn lockNss() void {
+    nss_mutex.lockUncancelable(getIo());
+}
+
+pub fn unlockNss() void {
+    nss_mutex.unlock(getIo());
+}
 
 /// Global allocator for NSS (using C allocator for compatibility)
 pub const nss_allocator = std.heap.c_allocator;
+
+/// NSS entry points are called from libc, so they cannot receive an `Io` from
+/// `std.process.Init` the way `main` does.
+///
+/// This library is dlopened into other people's processes, so it must not
+/// spawn threads or touch signal dispositions the way `Io.Threaded.init`
+/// does. The static instance does neither, and everything used here (config
+/// file reads, `std.http.Client`) is sequential, so the missing async and
+/// cancelation support costs nothing.
+pub fn getIo() std.Io {
+    return std.Io.Threaded.global_single_threaded.io();
+}
 
 /// Global state instance
 var global_state: ?GlobalState = null;

--- a/src/nss_group.zig
+++ b/src/nss_group.zig
@@ -67,8 +67,8 @@ pub fn packGroupStruct(
 
 /// setgrent - Initialize group enumeration
 pub fn setgrent(stayopen: c_int) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     _ = stayopen;
 
@@ -85,8 +85,8 @@ pub fn setgrent(stayopen: c_int) NssStatus {
 
 /// endgrent - End group enumeration
 pub fn endgrent() NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
     state.reset();
@@ -101,8 +101,8 @@ pub fn getgrent_r(
     buflen: usize,
     errnop: *c_int,
 ) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
 
@@ -146,8 +146,8 @@ pub fn getgrnam_r(
     buflen: usize,
     errnop: *c_int,
 ) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
 
@@ -191,8 +191,8 @@ pub fn getgrgid_r(
     buflen: usize,
     errnop: *c_int,
 ) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
 

--- a/src/nss_passwd.zig
+++ b/src/nss_passwd.zig
@@ -71,8 +71,8 @@ pub fn packPasswdStruct(
 
 /// setpwent - Initialize passwd enumeration
 pub fn setpwent(stayopen: c_int) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     _ = stayopen;
 
@@ -91,8 +91,8 @@ pub fn setpwent(stayopen: c_int) NssStatus {
 
 /// endpwent - End passwd enumeration
 pub fn endpwent() NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
     state.reset();
@@ -107,8 +107,8 @@ pub fn getpwent_r(
     buflen: usize,
     errnop: *c_int,
 ) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
 
@@ -152,8 +152,8 @@ pub fn getpwnam_r(
     buflen: usize,
     errnop: *c_int,
 ) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
 
@@ -196,8 +196,8 @@ pub fn getpwuid_r(
     buflen: usize,
     errnop: *c_int,
 ) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
 

--- a/src/nss_shadow.zig
+++ b/src/nss_shadow.zig
@@ -53,8 +53,8 @@ pub fn packShadowStruct(
 
 /// setspent - Initialize shadow enumeration
 pub fn setspent(stayopen: c_int) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     _ = stayopen;
 
@@ -71,8 +71,8 @@ pub fn setspent(stayopen: c_int) NssStatus {
 
 /// endspent - End shadow enumeration
 pub fn endspent() NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
     state.reset();
@@ -87,8 +87,8 @@ pub fn getspent_r(
     buflen: usize,
     errnop: *c_int,
 ) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
 
@@ -127,8 +127,8 @@ pub fn getspnam_r(
     buflen: usize,
     errnop: *c_int,
 ) NssStatus {
-    common.nss_mutex.lock();
-    defer common.nss_mutex.unlock();
+    common.lockNss();
+    defer common.unlockNss();
 
     const state = common.getGlobalState();
 

--- a/src/provider.zig
+++ b/src/provider.zig
@@ -15,10 +15,10 @@ pub const Provider = union(types.ProviderType) {
     const Self = @This();
 
     /// Initialize provider based on config
-    pub fn init(allocator: Allocator, config: *const config_mod.Config, logger: *log.Logger) Self {
+    pub fn init(allocator: Allocator, io: std.Io, config: *const config_mod.Config, logger: *log.Logger) Self {
         return switch (config.provider) {
-            .github => .{ .github = github_mod.GitHubProvider.init(allocator, config, logger) },
-            .gitlab => .{ .gitlab = gitlab_mod.GitLabProvider.init(allocator, config, logger) },
+            .github => .{ .github = github_mod.GitHubProvider.init(allocator, io, config, logger) },
+            .gitlab => .{ .gitlab = gitlab_mod.GitLabProvider.init(allocator, io, config, logger) },
         };
     }
 
@@ -63,7 +63,7 @@ test "Provider init GitHub" {
     config.provider = .github;
 
     var logger = log.Logger.init("test", false);
-    var provider = Provider.init(allocator, &config, &logger);
+    var provider = Provider.init(allocator, std.testing.io, &config, &logger);
     defer provider.deinit();
 
     try std.testing.expectEqual(types.ProviderType.github, @as(types.ProviderType, provider));
@@ -77,7 +77,7 @@ test "Provider init GitLab" {
     config.provider = .gitlab;
 
     var logger = log.Logger.init("test", false);
-    var provider = Provider.init(allocator, &config, &logger);
+    var provider = Provider.init(allocator, std.testing.io, &config, &logger);
     defer provider.deinit();
 
     try std.testing.expectEqual(types.ProviderType.gitlab, @as(types.ProviderType, provider));


### PR DESCRIPTION
## Why

The `Build` workflow has been failing on `macos-latest` since 2026-07-06, when the runner image moved from `macos-15-arm64` to `macos-26-arm64`. Every libSystem symbol came back undefined while linking the build runner itself:

```
error: undefined symbol: __availability_version_check
    note: referenced by .zig-cache/o/.../libcompiler_rt.a(libcompiler_rt_zcu.o):___isPlatformVersionAtLeast
error: undefined symbol: _abort
error: undefined symbol: _arc4random_buf
...
```

This is [ziglang/zig#31658](https://codeberg.org/ziglang/zig/issues/31658): the Xcode 26.4+ SDK added `arm64e-macos` entries to its `.tbd` stubs, and Zig's Mach-O linker did not match an `aarch64-macos` target against them. It affects 0.15.2 and was fixed upstream by #31673, released in 0.16.0.

## What

Bump the toolchain to 0.16.0 and migrate the source to its `Io` API.

0.16 routes all I/O through an explicit `Io` instance, so one is threaded from each entry point down through `Config`, `Cache` and the providers:

- `main` takes `std.process.Init` and passes `init.io` along.
- The NSS exports use `Io.Threaded.global_single_threaded`. The library is dlopened into other people's processes (sshd and friends), so it must not spawn threads or install signal handlers the way `Io.Threaded.init` does. Everything it drives — config file reads, `std.http.Client` — is sequential, so the missing async and cancelation support costs nothing.
- `std.fs` file operations move to `std.Io.Dir` / `std.Io.File`.
- `std.posix.getenv` is gone; the environment is read through libc instead.
- `ArrayListUnmanaged(T){}` becomes `ArrayList(T).empty`.

## Verification

- `zig build`, `zig build test`, `zig build cross` and `zig fmt --check` all pass locally on Zig 0.16.0.
- CLI smoke tested: `--version`, `--help`, relative `-c` path resolution, `OCTOPASS_*` environment overrides, and the `pam` stdin path (both a supplied token and empty input).
- `Build` is green on this branch, including `Test (macos-latest)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)