### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,10 @@
+octopass (1.3.0-1) DIST; urgency=medium
+
+  * Build with Zig 0.16.0
+  * Fix the macOS build broken by the Xcode 26.4+ SDK
+
+ -- linyows <linyows@gmail.com>  Tue, 28 Jul 2026 08:30:00 +0900
+
 octopass (1.2.0-1) DIST; urgency=medium
 
   * Add GitLab provider support

--- a/packaging/rpm/octopass.spec
+++ b/packaging/rpm/octopass.spec
@@ -1,6 +1,6 @@
 Summary:          Management linux user and authentication with team or collaborator on Github.
 Name:             octopass
-Version:          1.2.0
+Version:          1.3.0
 Release:          1%{?dist}
 License:          MIT
 URL:              https://github.com/linyows/octopass
@@ -98,6 +98,10 @@ fi
 %{_datadir}/selinux/packages/%{name}/%{name}.pp
 
 %changelog
+* Tue Jul 28 2026 linyows <linyows@gmail.com> - 1.3.0-1
+- Build with Zig 0.16.0
+- Fix the macOS build broken by the Xcode 26.4+ SDK
+
 * Mon May 25 2026 linyows <linyows@gmail.com> - 1.2.0-1
 - Add GitLab provider support
 - Change license from GPL-3.0 to MIT


### PR DESCRIPTION
Prepare the packaging metadata for the v1.3.0 tag. `rpmbuild` takes its version from the spec and `dpkg-buildpackage` from the Debian changelog, so both have to be bumped before the tag is pushed.

Changes since v1.2.0:

* Build with Zig 0.16.0
* Fix the macOS build broken by the Xcode 26.4+ SDK (#62)

🤖 Generated with [Claude Code](https://claude.com/claude-code)